### PR TITLE
creation /register, /login, /me

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,33 +1,62 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
 
-from backend.app.core.databse import get_db
+from backend.app.core.database import get_db
 from backend.app.schemas.user import UserCreate, UserLogin, UserOut
 from backend.app.models.user import User
 from backend.app.core.security import hash_password, verify_password, create_access_token
 
-
-
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+SECRET_KEY = "MACARRON"
+ALGORITHM = "HS256"
 
 @router.post("/register", response_model=UserOut)
 def register(user: UserCreate, db: Session = Depends(get_db)):
     if db.query(User).filter(User.username == user.username).first():
-        raise HTTPException(status_code = 400, detail = "Username already exists")
-    db_user = User (
-        username = user.username,
-        email = user.email,
-        hashed_password = hash_password(user.password)
+        raise HTTPException(status_code=400, detail="Username already exists")
+    if db.query(User).filter(User.email == user.email).first():
+        raise HTTPException(status_code=400, detail="Email already exists")
+    db_user = User(
+        username=user.username,
+        email=user.email,
+        hashed_password=hash_password(user.password)
     )
     db.add(db_user)
-    db.comimit()
+    db.commit()
     db.refresh(db_user)
     return db_user
 
 @router.post("/login")
-def login(credentials: UserLogin, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.username == credentials.username).first()
-    if not user or not verify_password(credentials.password, user.hashed_password):
-        raise HTTPException(status_code = 401, detail="Invalid credentials")
-    toekn = create_access_token(data={"sub": user.username})
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.username == form_data.username).first()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token(data={"sub": user.username})
     return {"access_token": token, "token_type": "bearer"}
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(User).filter(User.username == username).first()
+    if user is None:
+        raise credentials_exception
+    return user
+
+@router.get("/me", response_model=UserOut)
+def read_current_user(current_user: User = Depends(get_current_user)):
+    return current_user

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -4,7 +4,8 @@ from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-load_dotenv()
+dotenv_path = os.path.join(os.path.dirname(__file__), '../../.env')
+load_dotenv(dotenv_path)
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 

--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -1,4 +1,4 @@
-from backend.app.core.databse import engine
+from backend.app.core.database import engine, Base
 
 
 def init():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,43 @@
 from fastapi import FastAPI
-
+from fastapi.openapi.utils import get_openapi
+from fastapi.security import OAuth2PasswordBearer
 
 from backend.app.api import auth
-from backend.app.core.databse import Base, engine
+from backend.app.core.database import Base, engine
 
 app = FastAPI()
 app.include_router(auth.router)
 
 # Crea las tablas si no existen (sólo para desarrollo)
 Base.metadata.create_all(bind=engine)
+
+# Define el esquema OAuth2 para la documentación
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title="ThreatWatch API",
+        version="1.0.0",
+        description="API de autenticación para ThreatWatch",
+        routes=app.routes,
+    )
+    openapi_schema["components"]["securitySchemes"] = {
+        "OAuth2PasswordBearer": {
+            "type": "oauth2",
+            "flows": {
+                "password": {
+                    "tokenUrl": "/auth/login",
+                    "scopes": {}
+                }
+            }
+        }
+    }
+    for path in openapi_schema["paths"].values():
+        for method in path.values():
+            method.setdefault("security", [{"OAuth2PasswordBearer": []}])
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+app.openapi = custom_openapi

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, String
-from app.core.database import Base
+
+from backend.app.core.database import Base
 
 
 class User(Base):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, ConfigDict
+
 
 class UserCreate(BaseModel):
     username: str
@@ -14,5 +15,4 @@ class UserOut (BaseModel):
     username: str
     email: EmailStr
 
-class Config:
-    orm_mode = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary by Sourcery

Implement full JWT-based authentication flow, including registration, login via OAuth2, and current-user retrieval, while improving configuration, imports, and API documentation.

New Features:
- Add user registration endpoint with username, email and hashed password storage
- Implement OAuth2-based login endpoint issuing JWT access tokens
- Introduce /me endpoint to retrieve the current authenticated user

Bug Fixes:
- Prevent duplicate email registrations alongside username checks
- Fix typo in database commit call
- Correct database and model import paths

Enhancements:
- Load environment variables from specified .env path
- Switch Pydantic ORM mode to model_config with ConfigDict
- Replace custom login schema with OAuth2PasswordRequestForm for credential handling

Documentation:
- Enhance OpenAPI schema to include OAuth2 password flow and secure all endpoints

Chores:
- Update import paths in init_db and core modules